### PR TITLE
Add -lm command for Ubuntu 16.04 LTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OPENSSL_INCLUDE_DIR=$(OPENSSL_DIR)/include
 OPENSSL_LIB_DIR=$(OPENSSL_DIR)/lib
 
 CFLAGS=-O3 -std=gnu11 -Wall -Wextra -I$(OPENSSL_INCLUDE_DIR) #-DDEBUG_LOGS
-LDFLAGS=-L$(OPENSSL_LIB_DIR) -lcrypto -lssl
+LDFLAGS=-L$(OPENSSL_LIB_DIR) -lcrypto -lssl -lm
 
 all:
 	$(CC) $(CFLAGS) -o generate_a generate_a.c $(LDFLAGS) 


### PR DESCRIPTION
Hi, my name is Hyeongcheol An.

I use Ubuntu 16.04 LTS and gcc 5.4.0.
When I compile this source code, I got some error which is undefined sqrt() function.

So, I add -lm command in Makefile.

Thank you for nice work!